### PR TITLE
Only launch browser when interactive mode

### DIFF
--- a/R/launch_editor.R
+++ b/R/launch_editor.R
@@ -59,7 +59,7 @@ launch_editor <- function(app_loc,
                           app_preview = TRUE,
                           show_logs = TRUE,
                           show_preview_app_logs = TRUE,
-                          launch_browser = TRUE,
+                          launch_browser = interactive(),
                           stop_on_browser_close = TRUE) {
   writeLog <- function(...) {
     if (show_logs) {


### PR DESCRIPTION
Switches the default value of the `launch_browser` argument to `interactive()` so it won't try and launch when running non-interactively e.g. in RSW etc.. 