### PR TITLE
Fix bug when rstudio api is installed but editor is run outside of rstudio

### DIFF
--- a/R/AppPreviewClass.R
+++ b/R/AppPreviewClass.R
@@ -179,8 +179,9 @@ make_url_hosted_friendly <- function(local_url) {
 
   has_rstudioapi <- rlang::is_installed("rstudioapi")
   # If we can, run the URL through rstudioapi's url translator, otherwise just
-  # return the plain un-proxied url
-  if (has_rstudioapi) {
+  # return the plain un-proxied url We also need to check to make sure that
+  # we're running inside of RStudio before using the rstudio api package
+  if (has_rstudioapi && !get_running_outside_rstudio()) {
     rstudioapi::translateLocalUrl(local_url, absolute = TRUE)
   } else {
     local_url

--- a/R/check_for_url_issues.R
+++ b/R/check_for_url_issues.R
@@ -4,7 +4,7 @@
 # problem
 check_for_url_issues <- function() {
 
-  running_outside_rstudio <- identical(Sys.getenv("RSTUDIO"), "")
+  running_outside_rstudio <- get_running_outside_rstudio()
 
   # If we're not in RStudio we don't need to (/can't) do anything
   if (running_outside_rstudio) {
@@ -40,4 +40,8 @@ check_for_url_issues <- function() {
     "need to install the rstudioapi package.\n",
     "Run install.packages(\"rstudioapi\") to install it."
   )
+}
+
+get_running_outside_rstudio <- function() {
+  identical(Sys.getenv("RSTUDIO"), "")
 }


### PR DESCRIPTION

Was caused by only checking for rstudio api being installed rather than if it was installed _and_ the process was running inside of rstudio -- something that is necessary to use the rstudio api.