### PR TITLE
Make ast serialization more forgiving of calls of declared-in-scope functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# shinyuieditor 0.4.2
+
+### Major new features and improvements
+
+### Minor new features and improvements
+
+### Bug fixes
+
+- Fixed bug where reactive values (or any user-declared functions) were called in code. #148
+
 # shinyuieditor 0.4.1
 
 ### Major new features and improvements

--- a/R/serialize_ast.R
+++ b/R/serialize_ast.R
@@ -1,7 +1,6 @@
 # Take a parsed R expression and turn it into a fully serializable ast
-# representation. 
+# representation.
 serialize_ast <- function(raw_expr) {
-
   if (!is_serializable_node(raw_expr)) {
     stop(
       "Unknown expression type, can't parse. typeof(node) = ",
@@ -10,26 +9,24 @@ serialize_ast <- function(raw_expr) {
   }
 
   # Call any library calls so we know we have the proper environment to run
-  # argument matching  
+  # argument matching
   if (is_library_call(raw_expr)) {
     eval(raw_expr)
   }
 
   # Fill in all the names of unnamed arguments
   expr <- if (is.call(raw_expr)) {
-    tryCatch({
-      rlang::call_match(call = raw_expr, fn = eval(raw_expr[[1]]))
-    },
-    error = function(e) {
-        stop(
-          paste0(
-            "Problem with standardizing arguments supplied to expression.",
-            "\nError msg: \"",
-            e$message,
-            "\""
-          ),
-          call. = FALSE
-        )
+    # Try and fill in unknown arguments. We need to wrap this in try-catch in
+    # case we encounter an unknown function or an immediately invoked function
+    # which call_match won't be able to introspect on. If we fail here just
+    # return the call expression as we got it. Since we don't support functional
+    # ui definitions we don't have to worry about this messing up ui trees
+    tryCatch(
+      {
+        rlang::call_match(call = raw_expr, fn = eval(raw_expr[[1]]))
+      },
+      error = function(e) {
+        return(raw_expr)
       }
     )
   } else {
@@ -37,20 +34,19 @@ serialize_ast <- function(raw_expr) {
   }
 
   node_names <- names(expr)
-   
+
   ast_node <- c()
 
   # We use a for loop here instead of an apply function because we need access
   # to the index for querying source refs
   for (i in seq_along(expr)) {
-    
     val <- parse_ast_node_value(
       x = expr[[i]],
-      name = node_names[i], 
+      name = node_names[i],
       node_pos = get_source_position(attr(expr, "srcref")[[i]])
     )
-    
-    if (length(val) > 0) {      
+
+    if (length(val) > 0) {
       ast_node[[length(ast_node) + 1]] <- val
     }
   }
@@ -65,65 +61,65 @@ serialize_ast <- function(raw_expr) {
 # node
 
 parse_ast_node_value <- function(x, name, node_pos) {
-    
-    # If the node is a call with named args and unnamed ones then we may have an
-    # empty character as the name, which we should treat as missing
-    if (identical(name, "")) {
-      name <- NULL
-    }
+
+  # If the node is a call with named args and unnamed ones then we may have an
+  # empty character as the name, which we should treat as missing
+  if (identical(name, "")) {
+    name <- NULL
+  }
 
 
-    val_type <- "u"
-    # Things like df[,1] will have a "missing" node in the ast for the first
-    # argument of `[`,
-    val <- if (missing(x) || identical(class(x), "srcref")) {
-      val_type <- "m"
-      NULL
-    } else if (is.atomic(x)) {
-      # Numbers, and characters etc..
-      val_type <- if (is.character((x))) {
-        "c"
-      } else if (is.numeric(x)) {
-        "n"
-      } else if (is.logical(x)) {
-        "b"
-      } else {
-        "u"
-      }
-      x
-    } else if (is.symbol(x) || is_namespace_call(x)) {
-      # Things like variable names and other syntactically relevant symbols
-      val_type <- "s"
-      deparse(x)
+  val_type <- "u"
+  # Things like df[,1] will have a "missing" node in the ast for the first
+  # argument of `[`,
+  val <- if (missing(x) || identical(class(x), "srcref")) {
+    val_type <- "m"
+    NULL
+  } else if (is.atomic(x)) {
+    # Numbers, and characters etc..
+    val_type <- if (is.character((x))) {
+      "c"
+    } else if (is.numeric(x)) {
+      "n"
+    } else if (is.logical(x)) {
+      "b"
     } else {
-      # This will error if we give it a non-ast-valid node so no need to do
-      # exhaustive checks in this logic
-      val_type <- "e"
-      serialize_ast(x)   
+      "u"
     }
+    x
+  } else if (is.symbol(x) || is_namespace_call(x)) {
+    # Things like variable names and other syntactically relevant symbols
+    val_type <- "s"
+    deparse(x)
+  } else {
+    # This will error if we give it a non-ast-valid node so no need to do
+    # exhaustive checks in this logic
+    val_type <- "e"
+    serialize_ast(x)
+  }
 
-    node <- list()
-    node$name <- name
-    node$val <- val
-    node$type <- val_type
-    node$pos <- node_pos
+  node <- list()
+  node$name <- name
+  node$val <- val
+  node$type <- val_type
+  node$pos <- node_pos
 
-    # If we have an unnamed argument that has an empty value then it's missing
-    # and is probably caused by a trailing comma or something. We just remove
-    # these
-    if (identical(node$val, "") && is.null(node$name)) {
-      return(NULL)
-    }
+  # If we have an unnamed argument that has an empty value then it's missing
+  # and is probably caused by a trailing comma or something. We just remove
+  # these
+  if (identical(node$val, "") && is.null(node$name)) {
+    return(NULL)
+  }
 
-    # Empty missing nodes just get removed.
-    if (identical(val_type, "m") && is.null(node$name)) {
-      return(NULL)
-    }
-      
-    node 
+  # Empty missing nodes just get removed.
+  if (identical(val_type, "m") && is.null(node$name)) {
+    return(NULL)
+  }
+
+  node
 }
 
-# Translate the raw integer array into meaningful position values. 
+# Translate the raw integer array into meaningful position values.
 # Tuple is (line#, column#)
 get_source_position <- function(source_ref) {
   if (is.null(source_ref)) {
@@ -143,12 +139,12 @@ is_namespace_call <- function(expr) {
 
 is_serializable_node <- function(x) {
   node_type <- typeof(x)
-  identical(node_type, "pairlist") || 
-    identical(node_type, "language") || 
+  identical(node_type, "pairlist") ||
+    identical(node_type, "language") ||
     identical(node_type, "expression")
 }
 
 is_library_call <- function(expr) {
-  identical(typeof(expr[[1]]), "symbol") && 
+  identical(typeof(expr[[1]]), "symbol") &&
     identical(rlang::as_string(expr[[1]]), "library")
 }

--- a/scratch/ast_generation_scratch.R
+++ b/scratch/ast_generation_scratch.R
@@ -3,16 +3,15 @@ library(lobstr)
 library(shiny)
 library(bslib)
 
-
-make_px <- function(num) {paste0(num, "px")}
-  card_height <- "200px"
 rlang::expr(
-   card_body_fill(
-      max_height = make_px(100)
-      )
-)|> 
- serialize_ast() |> 
- jsonlite::toJSON(auto_unbox = TRUE)
+  {
+    my_fn <- function(name) paste("hello", name)
+    my_fn("shiny")
+  }
+) |>
+ serialize_ast() |>
+tree(index_unnamed = TRUE)
+ # jsonlite::toJSON(auto_unbox = TRUE)
 
 
 # file_lines <- readLines("scratch/app-w-unknown-code/app.R")

--- a/scratch/reactive-val/app.R
+++ b/scratch/reactive-val/app.R
@@ -1,0 +1,62 @@
+library(shiny)
+library(gridlayout)
+library(bslib)
+
+
+ui <- navbarPage(
+  title = "Chick Weights",
+  selected = "Empty Tab",
+  collapsible = TRUE,
+  theme = bslib::bs_theme(),
+  tabPanel(
+    title = "Empty Tab",
+    grid_container(
+      layout = c(
+        "nums square",
+        "nums square"
+      ),
+      row_sizes = c(
+        "1fr",
+        "1fr"
+      ),
+      col_sizes = c(
+        "1fr",
+        "1fr"
+      ),
+      gap_size = "10px",
+      grid_card(
+        area = "nums",
+        full_screen = TRUE,
+        card_header("Header"),
+        card_body_fill(
+          sliderInput(
+            inputId = "inputId",
+            label = "Slider Input",
+            min = 0,
+            max = 10,
+            value = 5,
+            width = "100%"
+          )
+        )
+      ),
+      grid_card(
+        area = "square",
+        full_screen = TRUE,
+        card_header("Header"),
+        card_body_fill(textOutput(outputId = "squared"))
+      )
+    )
+  )
+)
+
+
+server <- function(input, output) {
+  numsqr <- reactive({input$inputId ^ 2})
+
+output$squared <- renderText({
+  paste0("the square of ", input$inputId, " is ", numsqr())
+})
+
+}
+
+shinyApp(ui, server)

--- a/scratch/start_editor_non_interactive.R
+++ b/scratch/start_editor_non_interactive.R
@@ -1,7 +1,7 @@
 devtools::load_all(".")
 library(lobstr)
 launch_editor(
-  app_loc =  here::here("scratch/single-file-app/"),
+  app_loc =  here::here("scratch/bare-reactives/"),
   port = 8888,
   launch_browser = FALSE,
   stop_on_browser_close = FALSE

--- a/tests/testthat/test-serialize_ast.R
+++ b/tests/testthat/test-serialize_ast.R
@@ -17,3 +17,26 @@ test_that("Can fill in unnamed named arguments", {
     "myArea"
   )
 })
+
+
+test_that("Can handle functions declared in scope. E.g. reactives.", {
+  expr_with_fn_declaration <- rlang::expr(
+    {
+      my_fn <- function(name) paste("hello", name)
+      my_fn("shiny")
+    }
+  )
+
+  serialized <- serialize_ast(expr_with_fn_declaration)
+
+  my_fn_call <- serialized[[3]]
+
+  expect_equal(
+    my_fn_call$val,
+    list(
+      list(val="my_fn", type="s"),
+      list(val="shiny", type="c")
+    )
+
+  )
+})


### PR DESCRIPTION
This is a fix for the bug in #148 . 

## Problem
In code to serialize from R code to the general purpose ast the use of `rlang::call_match()` is not able to handle the case where the function itself is not defined for the calling environment that `call_match()` is run. This means declaring a function inside your server function or app script and then calling it would break the serialization. 

## Fix
The fix, in this case, is to just not error when we encounter this situation and pass the non-matched function expression on. This is safe to do because we only need the named arguments separated properly for editable UI code, where any recently declared functions won't fall into this situation anyways. 