### PR TITLE
Smarter ID input

### DIFF
--- a/inst/editor/build/index.html
+++ b/inst/editor/build/index.html
@@ -26,7 +26,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Shiny UI Editor</title>
-    <script type="module" crossorigin src="./assets/index-efd3db4e.js"></script>
+    <script type="module" crossorigin src="./assets/index-50a861e8.js"></script>
     <link rel="stylesheet" href="./assets/index-f1164b56.css">
   </head>
 

--- a/inst/editor/src/components/Inputs/SettingsFormBuilder/FormBuilder.tsx
+++ b/inst/editor/src/components/Inputs/SettingsFormBuilder/FormBuilder.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import { is_object } from "util-functions/src/is_object";
 import type { StringKeys } from "util-functions/src/TypescriptUtils";
 
-import { getAllBindingIds } from "../../../EditorContainer/getAllBindingIds";
 import type { AllInputTypes } from "../../../ui-node-definitions/inputFieldTypes";
 import type { NodePath } from "../../../ui-node-definitions/NodePath";
 import type { ShinyUiNode } from "../../../ui-node-definitions/ShinyUiNode";
@@ -16,7 +15,6 @@ import type {
 } from "./SettingsInput/SettingsInput";
 import { SettingsInput } from "./SettingsInput/SettingsInput";
 import "./styles.scss";
-import { ExistingValuesProvider } from "./SettingsInput/StringInput";
 import { UnknownArgumentsRender } from "./UnknownArgumentsRender";
 
 type SettingsObj = Record<string, unknown>;
@@ -114,46 +112,12 @@ function knownArgumentInputs({
       onUpdate: (updatedAction) => onSettingsChange(arg_name, updatedAction),
     } as SettingsInputProps;
 
-    const settingsInput = (
+    InputsComponents[arg_name] = (
       <SettingsInput
         key={node.id + arg_name + nodePath.join("-")}
         {...inputProps}
       />
     );
-
-    // This logic is to prevent the situation where we have duplicate IDs for
-    // inputs and outputs.
-    if (
-      (arg_name === "id" ||
-        arg_name === "inputId" ||
-        arg_name === "outputId") &&
-      typeof current_arg_value === "string"
-    ) {
-      const bindingIds = getAllBindingIds(app_tree);
-
-      // Just remove the first instance of a node's id from the array of seen
-      // ids. This will make sure that duplicate values will always show up as
-      // an error because if we just delete the the value from a set then it
-      // looks like it's not a duplicate.
-      const thisNodeIdIndex = bindingIds.indexOf(current_arg_value);
-      if (thisNodeIdIndex !== -1) {
-        bindingIds.splice(thisNodeIdIndex, 1);
-      }
-
-      // Now wrap this input with a context provider of off limits values.
-      InputsComponents[arg_name] = (
-        <ExistingValuesProvider
-          offLimitValues={{
-            existingValues: new Set(bindingIds),
-            warningMsg: (value: string) => `The id ${value} is already taken`,
-          }}
-        >
-          {settingsInput}
-        </ExistingValuesProvider>
-      );
-    } else {
-      InputsComponents[arg_name] = settingsInput;
-    }
   }
 
   return InputsComponents;

--- a/inst/editor/src/components/Inputs/SettingsFormBuilder/SettingsInput/IdInput.tsx
+++ b/inst/editor/src/components/Inputs/SettingsFormBuilder/SettingsInput/IdInput.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+
+import { getAllBindingIds } from "../../../../EditorContainer/getAllBindingIds";
+import { useCurrentAppInfo } from "../../../../state/app_info";
+import type { InputComponentByType } from "../../../../ui-node-definitions/inputFieldTypes";
+import { makeLabelId } from "../../../../ui-node-definitions/inputFieldTypes";
+
+import { ExistingValuesProvider, existingValuesContext } from "./StringInput";
+
+const bindingIds = new Set(["myid", "taken"]);
+
+export function IdInput({
+  id,
+  label,
+  value,
+  onChange,
+  inputOrOutput,
+}: InputComponentByType<"id">) {
+  // It's totally possible this is a terrible idea and I should be passing the
+  // UI tree down instead. Right now performance seems fine though especially
+  // since this is a leaf node
+  const appInfo = useCurrentAppInfo();
+
+  const [currValue, setCurrValue] = React.useState(value);
+  const [invalidMsg, setInvalidMsg] = React.useState<null | string>(null);
+
+  if (appInfo.mode !== "MAIN") return null;
+
+  const app_tree = appInfo.ui_tree;
+
+  const bindingIds = getAllBindingIds(app_tree);
+
+  const updateValue = (newValue: string) => {
+    // Check if the requested new value is already in use and set invalid if it is
+    const takenId = bindingIds.includes(newValue) && newValue !== value;
+
+    // TODO: Update this to now allow spaces or other special characters in the id
+    setCurrValue(newValue);
+
+    if (takenId) {
+      setInvalidMsg(`The id ${newValue} is already taken`);
+    } else {
+      onChange(newValue);
+      setInvalidMsg(null);
+    }
+  };
+
+  const isInvalid = invalidMsg !== null;
+
+  const common_props = {
+    className: "SUE-Input",
+    "aria-label": label,
+    "aria-labelledby": makeLabelId(id),
+    "aria-invalid": isInvalid,
+    id,
+    value: currValue,
+    onChange: (
+      e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+    ) => {
+      updateValue(e.target.value);
+    },
+  };
+
+  return (
+    <>
+      <input {...common_props} type="text" />
+      {invalidMsg && (
+        <div className="text-danger">
+          <small>{invalidMsg}</small>
+        </div>
+      )}
+    </>
+  );
+}

--- a/inst/editor/src/components/Inputs/SettingsFormBuilder/SettingsInput/IdInput.tsx
+++ b/inst/editor/src/components/Inputs/SettingsFormBuilder/SettingsInput/IdInput.tsx
@@ -5,10 +5,6 @@ import { useCurrentAppInfo } from "../../../../state/app_info";
 import type { InputComponentByType } from "../../../../ui-node-definitions/inputFieldTypes";
 import { makeLabelId } from "../../../../ui-node-definitions/inputFieldTypes";
 
-import { ExistingValuesProvider, existingValuesContext } from "./StringInput";
-
-const bindingIds = new Set(["myid", "taken"]);
-
 export function IdInput({
   id,
   label,
@@ -34,7 +30,9 @@ export function IdInput({
     // Check if the requested new value is already in use and set invalid if it is
     const takenId = bindingIds.includes(newValue) && newValue !== value;
 
-    // TODO: Update this to now allow spaces or other special characters in the id
+    // Replace spaces with underscores
+    newValue = newValue.replace(/ /g, "_");
+
     setCurrValue(newValue);
 
     if (takenId) {

--- a/inst/editor/src/components/Inputs/SettingsFormBuilder/SettingsInput/SettingsInputElement.tsx
+++ b/inst/editor/src/components/Inputs/SettingsFormBuilder/SettingsInput/SettingsInputElement.tsx
@@ -9,6 +9,7 @@ import { NumberInput } from "../../NumberInput/NumberInput";
 import { DropdownSelect } from "../../OptionsDropdown/DropdownSelect";
 import { RadioInputs } from "../../RadioInputs/RadioInputsSimple";
 
+import { IdInput } from "./IdInput";
 import { StringInput } from "./StringInput";
 
 type SettingsInputElementProps = InputOptions & {
@@ -39,6 +40,8 @@ export function SettingsInputElement(args: SettingsInputElementProps) {
       return <DropdownSelect {...args} />;
     case "radio":
       return <RadioInputs {...args} />;
+    case "id":
+      return <IdInput {...args} />;
     default:
       return (
         <div>

--- a/inst/editor/src/components/Inputs/SettingsFormBuilder/SettingsInput/StringInput.tsx
+++ b/inst/editor/src/components/Inputs/SettingsFormBuilder/SettingsInput/StringInput.tsx
@@ -16,7 +16,7 @@ export type OffLimitsValues = {
 /**
  * A context object to hold a list of values that are off limits for the input.
  */
-const existingValuesContext = React.createContext<OffLimitsValues>({
+export const existingValuesContext = React.createContext<OffLimitsValues>({
   existingValues: new Set(),
   warningMsg: (value: string) => `The value ${value} is already taken`,
 });

--- a/inst/editor/src/components/Inputs/SettingsFormBuilder/SettingsInput/valueIsType.tsx
+++ b/inst/editor/src/components/Inputs/SettingsFormBuilder/SettingsInput/valueIsType.tsx
@@ -23,7 +23,7 @@ export function valueIsType(
     );
   }
 
-  if (type === "string") {
+  if (type === "string" || type === "id") {
     return typeof value === "string";
   }
 

--- a/inst/editor/src/index.tsx
+++ b/inst/editor/src/index.tsx
@@ -9,11 +9,11 @@ import { setupStaticBackend } from "./backendCommunication/staticBackend";
 import { setupWebsocketBackend } from "./backendCommunication/websocketBackend";
 import { DEV_MODE } from "./env_variables";
 import { runSUE } from "./runSUE";
-// import { basicNavbarPage as devModeTree } from "./ui-node-definitions/sample_ui_trees/basicNavbarPage";
+import { basicNavbarPage as devModeTree } from "./ui-node-definitions/sample_ui_trees/basicNavbarPage";
 import type { ShinyUiRootNode } from "./ui-node-definitions/ShinyUiNode";
 // import { bslibCards as devModeTree } from "./state/sample_ui_trees/bslibCards";
 // import { errorTestingTree as devModeTree } from "./state/sample_ui_trees/errorTesting";
-const devModeTree = "TEMPLATE_CHOOSER" as ShinyUiRootNode;
+// const devModeTree = "TEMPLATE_CHOOSER" as ShinyUiRootNode;
 
 // const language: LanguageMode = "PYTHON";
 // const language: LanguageMode = "R";

--- a/inst/editor/src/ui-node-definitions/Bslib/page_navbar.ts
+++ b/inst/editor/src/ui-node-definitions/Bslib/page_navbar.ts
@@ -32,7 +32,7 @@ export const page_navbar = nodeInfoFactory<{
       defaultValue: false,
     },
     id: {
-      inputType: "string",
+      inputType: "id",
       label: "Id for tabset",
       defaultValue: "tabset-default-id",
       optional: true,

--- a/inst/editor/src/ui-node-definitions/Bslib/sidebar.ts
+++ b/inst/editor/src/ui-node-definitions/Bslib/sidebar.ts
@@ -25,7 +25,7 @@ export const sidebar = nodeInfoFactory<{
       defaultValue: "Sidebar Title",
     },
     id: {
-      inputType: "string",
+      inputType: "id",
       label: "Id for tabset",
       defaultValue: "tabset-default-id",
       optional: true,

--- a/inst/editor/src/ui-node-definitions/DT/output_dt.ts
+++ b/inst/editor/src/ui-node-definitions/DT/output_dt.ts
@@ -21,7 +21,8 @@ export const output_dt = nodeInfoFactory<{
   takesChildren: false,
   settingsInfo: {
     outputId: {
-      inputType: "string",
+      inputType: "id",
+      inputOrOutput: "output",
       label: "Output ID",
       defaultValue: "myTable",
     },

--- a/inst/editor/src/ui-node-definitions/Shiny/input_action_button.ts
+++ b/inst/editor/src/ui-node-definitions/Shiny/input_action_button.ts
@@ -21,7 +21,8 @@ export const input_action_button = nodeInfoFactory<{
   takesChildren: false,
   settingsInfo: {
     inputId: {
-      inputType: "string",
+      inputType: "id",
+      inputOrOutput: "input",
       label: "inputId",
       defaultValue: "myButton",
     },

--- a/inst/editor/src/ui-node-definitions/Shiny/input_checkbox.ts
+++ b/inst/editor/src/ui-node-definitions/Shiny/input_checkbox.ts
@@ -22,7 +22,8 @@ export const input_checkbox = nodeInfoFactory<{
   takesChildren: false,
   settingsInfo: {
     inputId: {
-      inputType: "string",
+      inputType: "id",
+      inputOrOutput: "input",
       label: "inputId",
       defaultValue: "myCheckboxInput",
     },

--- a/inst/editor/src/ui-node-definitions/Shiny/input_checkbox_group.ts
+++ b/inst/editor/src/ui-node-definitions/Shiny/input_checkbox_group.ts
@@ -23,7 +23,8 @@ export const input_checkbox_group = nodeInfoFactory<{
   takesChildren: false,
   settingsInfo: {
     inputId: {
-      inputType: "string",
+      inputType: "id",
+      inputOrOutput: "input",
       label: "inputId",
       defaultValue: "myCheckboxGroup",
     },

--- a/inst/editor/src/ui-node-definitions/Shiny/input_numeric.ts
+++ b/inst/editor/src/ui-node-definitions/Shiny/input_numeric.ts
@@ -25,7 +25,8 @@ export const input_numeric = nodeInfoFactory<{
   takesChildren: false,
   settingsInfo: {
     inputId: {
-      inputType: "string",
+      inputType: "id",
+      inputOrOutput: "input",
       label: "inputId",
       defaultValue: "myNumericInput",
     },

--- a/inst/editor/src/ui-node-definitions/Shiny/input_radio_buttons.ts
+++ b/inst/editor/src/ui-node-definitions/Shiny/input_radio_buttons.ts
@@ -23,7 +23,8 @@ export const input_radio_buttons = nodeInfoFactory<{
   takesChildren: false,
   settingsInfo: {
     inputId: {
-      inputType: "string",
+      inputType: "id",
+      inputOrOutput: "input",
       label: "inputId",
       defaultValue: "myRadioButtons",
     },

--- a/inst/editor/src/ui-node-definitions/Shiny/input_select.ts
+++ b/inst/editor/src/ui-node-definitions/Shiny/input_select.ts
@@ -28,7 +28,8 @@ export const input_select = nodeInfoFactory<ShinySelectInputProps>()({
   takesChildren: false,
   settingsInfo: {
     inputId: {
-      inputType: "string",
+      inputType: "id",
+      inputOrOutput: "input",
       label: "inputId",
       defaultValue: "mySelectInput",
     },

--- a/inst/editor/src/ui-node-definitions/Shiny/input_slider.ts
+++ b/inst/editor/src/ui-node-definitions/Shiny/input_slider.ts
@@ -25,8 +25,9 @@ export const input_slider = nodeInfoFactory<{
   takesChildren: false,
   settingsInfo: {
     inputId: {
+      inputType: "id",
+      inputOrOutput: "input",
       label: "Input ID",
-      inputType: "string",
       defaultValue: "inputId",
     },
     label: {

--- a/inst/editor/src/ui-node-definitions/Shiny/input_text.ts
+++ b/inst/editor/src/ui-node-definitions/Shiny/input_text.ts
@@ -23,7 +23,8 @@ export const input_text = nodeInfoFactory<{
   takesChildren: false,
   settingsInfo: {
     inputId: {
-      inputType: "string",
+      inputType: "id",
+      inputOrOutput: "input",
       label: "inputId",
       defaultValue: "myTextInput",
     },

--- a/inst/editor/src/ui-node-definitions/Shiny/output_plot.ts
+++ b/inst/editor/src/ui-node-definitions/Shiny/output_plot.ts
@@ -31,7 +31,8 @@ export const output_plot = nodeInfoFactory<{
   takesChildren: false,
   settingsInfo: {
     outputId: {
-      inputType: "string",
+      inputType: "id",
+      inputOrOutput: "output",
       label: "Output ID for plot",
       defaultValue: "plot",
     },

--- a/inst/editor/src/ui-node-definitions/Shiny/output_text.ts
+++ b/inst/editor/src/ui-node-definitions/Shiny/output_text.ts
@@ -28,8 +28,8 @@ export const output_text = nodeInfoFactory<{
   takesChildren: false,
   settingsInfo: {
     outputId: {
+      inputType: "id",
       label: "Output ID",
-      inputType: "string",
       defaultValue: "textOutput",
     },
   },

--- a/inst/editor/src/ui-node-definitions/Shiny/output_ui.ts
+++ b/inst/editor/src/ui-node-definitions/Shiny/output_ui.ts
@@ -28,8 +28,8 @@ export const output_ui = nodeInfoFactory<{
   takesChildren: false,
   settingsInfo: {
     outputId: {
+      inputType: "id",
       label: "Output ID",
-      inputType: "string",
       defaultValue: "dynamicUiOutput",
     },
   },

--- a/inst/editor/src/ui-node-definitions/Shiny/tabset_panel.ts
+++ b/inst/editor/src/ui-node-definitions/Shiny/tabset_panel.ts
@@ -19,9 +19,10 @@ export const tabset_panel = nodeInfoFactory<{
   takesChildren: true,
   settingsInfo: {
     id: {
-      inputType: "string",
+      inputType: "id",
       label: "Id for tabset",
       defaultValue: "tabset-default-id",
+      inputOrOutput: "input",
       optional: true,
     },
     selected: {

--- a/inst/editor/src/ui-node-definitions/gridlayout/grid_card_plot.ts
+++ b/inst/editor/src/ui-node-definitions/gridlayout/grid_card_plot.ts
@@ -29,7 +29,7 @@ export const grid_card_plot = nodeInfoFactory<{
     },
     outputId: {
       label: "Output ID",
-      inputType: "string",
+      inputType: "id",
       defaultValue: function (node): string {
         if (node && "area" in node.namedArgs) {
           return node.namedArgs.area as string;

--- a/inst/editor/src/ui-node-definitions/inputFieldTypes.ts
+++ b/inst/editor/src/ui-node-definitions/inputFieldTypes.ts
@@ -16,6 +16,9 @@ export type CSSUnitWAuto = CSSUnit | "auto";
 type NamedList = Record<string, string>;
 
 export type InputOptions =
+  // Special ID input. Like a string input but enforces things like no spaces or
+  // special characters. Also checks to make sure ids are unique etc.
+  | { inputType: "id"; value: string; inputOrOutput: "input" | "output" }
   | { inputType: "string"; value: string; longform?: boolean }
   | {
       inputType: "number";
@@ -57,7 +60,7 @@ type ArgTypeToInputType<Arg extends unknown> = Arg extends number
   : Arg extends CSSMeasure
   ? "cssMeasure"
   : Arg extends string
-  ? "string" | "dropdown" | "radio"
+  ? "string" | "dropdown" | "radio" | "id"
   : Arg extends boolean
   ? "boolean"
   : Arg extends NamedList

--- a/inst/editor/src/ui-node-definitions/inputFieldTypes.ts
+++ b/inst/editor/src/ui-node-definitions/inputFieldTypes.ts
@@ -18,7 +18,7 @@ type NamedList = Record<string, string>;
 export type InputOptions =
   // Special ID input. Like a string input but enforces things like no spaces or
   // special characters. Also checks to make sure ids are unique etc.
-  | { inputType: "id"; value: string; inputOrOutput: "input" | "output" }
+  | { inputType: "id"; value: string; inputOrOutput?: "input" | "output" }
   | { inputType: "string"; value: string; longform?: boolean }
   | {
       inputType: "number";

--- a/inst/editor/src/ui-node-definitions/plotly/output_plotly.ts
+++ b/inst/editor/src/ui-node-definitions/plotly/output_plotly.ts
@@ -21,7 +21,8 @@ export const output_plotly = nodeInfoFactory<{
   takesChildren: false,
   settingsInfo: {
     outputId: {
-      inputType: "string",
+      inputType: "id",
+      inputOrOutput: "output",
       label: "Output ID for plot",
       defaultValue: "plot",
     },


### PR DESCRIPTION
This PR adds a new `inputType` for the configuration of UI nodes called `"id"`. This type is similar to the standard string input but it makes sure that inputs arent repeated and don't have spaces in them. Will open up further smart behavior for ids such as auto-changing server code to reflect new id etc..